### PR TITLE
do not force http protocol versions for api

### DIFF
--- a/src/kube_vxlan_controller_k8s.erl
+++ b/src/kube_vxlan_controller_k8s.erl
@@ -42,7 +42,6 @@ init([#{server := Server, ca_cert_file := CaCertFile}]) ->
 
     {Host, Port} = uri_parse(Server),
     Opts = #{connect_timeout => ?TIMEOUT,
-	     protocols => [http2],
 	     transport => tls,
 	     tls_opts => [{cacertfile, CaCertFile}]
 	    },
@@ -119,7 +118,6 @@ ws_connect(Resource, Query,
 	   #{server := Server, ca_cert_file := CaCertFile, token := Token}) ->
     {Host, Port} = uri_parse(Server),
     Opts = #{connect_timeout => ?HttpStreamRecvTimeout,
-	     protocols => [http],
 	     transport => tls,
 	     tls_opts => [{cacertfile, CaCertFile}]
 	    },

--- a/src/kube_vxlan_controller_run.erl
+++ b/src/kube_vxlan_controller_run.erl
@@ -53,7 +53,6 @@ init([#{server := Server, ca_cert_file := CaCertFile} = Config]) ->
 
     {Host, Port} = ?K8s:uri_parse(Server),
     Opts = #{connect_timeout => ?TIMEOUT,
-	     protocols => [http2],
 	     transport => tls,
 	     tls_opts => [{cacertfile, CaCertFile}]
 	    },


### PR DESCRIPTION
There is no requirement to use http2 in kubernetes api.
Since we use transport=>tls, by default gun will try http2 and fallback to http.