### PR TITLE
Add pod uid to the pod registry key

### DIFF
--- a/include/kube_vxlan_controller.hrl
+++ b/include/kube_vxlan_controller.hrl
@@ -1,1 +1,1 @@
--record(uid, {id, cycle}).
+-record(uid, {id, uid, cycle}).

--- a/src/kube_vxlan_controller_pod.erl
+++ b/src/kube_vxlan_controller_pod.erl
@@ -50,8 +50,8 @@ stop(Server) ->
 init_state(Server) ->
     gen_statem:cast(Server, init).
 
-process_event(Cycle, Type, #{pod_name := Name} = Pod, Config) ->
-    ?PodReg:process_event(#uid{id = Name, cycle = Cycle}, {Type, Pod}, Config).
+process_event(Cycle, Type, #{pod_name := Name, pod_uid := PodUid} = Pod, Config) ->
+    ?PodReg:process_event(#uid{id = Name, uid = PodUid, cycle = Cycle}, {Type, Pod}, Config).
 
 bridge_cmd(Action, Version, #{owner := Pid} = Pod, NetNames, IP) ->
     gen_statem:cast(Pid, {bridge_cmd, Action, Version, Pod, NetNames, IP}).


### PR DESCRIPTION
The controller clears the data related to a pod when it is
deleted/restarted from the pod registry ets table. But the key
that is represented by the pod name is still in the ets table.

This may lead to the situation when start of new pod will be handled
incorrectly, as for example if the new pod name is the same that
previous as in statefulsets.

This commit adds pod uid to the key to make keys uniq regardless
pod names.